### PR TITLE
Adds scp096AddTargetEvent.

### DIFF
--- a/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
+++ b/Smod2/EventSystem/EventHandlers/PlayerEventHandlers.cs
@@ -466,4 +466,12 @@ namespace Smod2.EventHandlers
 		/// </summary>
 		void OnScp096CooldownEnd(Scp096CooldownEndEvent ev);
 	}
+
+	public interface IEventHandlerScp096AddTarget : IEventHandler
+	{
+		/// <summary>
+		/// Called when SCP-096 adds a target.
+		/// </summary>
+		void OnScp096AddTarget(Scp096AddTargetEvent ev);
+	}
 }

--- a/Smod2/EventSystem/Events/PlayerEvents.cs
+++ b/Smod2/EventSystem/Events/PlayerEvents.cs
@@ -1035,4 +1035,21 @@ namespace Smod2.Events
 			((IEventHandlerScp096CooldownEnd)handler).OnScp096CooldownEnd(this);
 		}
 	}
+
+	public class Scp096AddTargetEvent : PlayerEvent
+	{
+		public bool Allow { get; set; }
+		public Player Target { get; }
+
+		public Scp096AddTargetEvent(Player scp096, Player target, bool allow = true) : base(scp096)
+		{
+			Allow = allow;
+			Target = target;
+		}
+
+		public override void ExecuteHandler(IEventHandler handler)
+		{
+			((IEventHandlerScp096AddTarget)handler).OnScp096AddTarget(this);
+		}
+	}
 }


### PR DESCRIPTION
Adds `Scp096AddTargetEvent` which triggers whenever someone looks at SCP-096. 

Has `Allow` which will stop 096 from raging when set to false, the `Target` as a player who looked at 096 and SCP-096 as `Player`.