### PR TITLE
914 rework

### DIFF
--- a/Smod2/EventSystem/Events/EnvironmentEvents.cs
+++ b/Smod2/EventSystem/Events/EnvironmentEvents.cs
@@ -1,5 +1,6 @@
 using Smod2.API;
 using Smod2.EventHandlers;
+using System.Collections.Generic;
 
 namespace Smod2.Events
 {
@@ -7,15 +8,17 @@ namespace Smod2.Events
 	{
 		public Player User { get; }
 		public KnobSetting KnobSetting { get; set; }
-		public object[] Inputs { get; set; } //TODO: Proper wrapping API
+		public List<Player> PlayerInputs { get; set; }
+		public List<Item> ItemInputs { get; set; }
 		public Vector IntakePos { get; set; }
 		public Vector OutputPos { get; set; }
 
-		public SCP914ActivateEvent(Player user, KnobSetting knobSetting, object[] inputs, Vector intakePos, Vector outputPos)
+		public SCP914ActivateEvent(Player user, KnobSetting knobSetting, List<Player> playerList, List<Item> itemList, Vector intakePos, Vector outputPos)
 		{
 			this.User = user;
 			this.KnobSetting = knobSetting;
-			this.Inputs = inputs;
+			this.PlayerInputs = playerList;
+			this.ItemInputs = itemList;
 			this.IntakePos = intakePos;
 			this.OutputPos = outputPos;
 		}


### PR DESCRIPTION
`SCP914ActivateEvent` rework, instead of object list of inputs that could be either a player or an item it returns list of items called `ItemInputs` and list of players called `PlayerInputs`
Reason being that you have to do everything yourself and isn't very intuitive to use